### PR TITLE
Add function to clear special characters

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,73 @@
+kind: pipeline
+type: docker
+name: push-latest
+steps:
+- name: build-and-push
+  image: plugins/docker
+  settings:
+    repo: ${DRONE_REPO}
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+trigger:
+  branch:
+  - master
+  event:
+    exclude:
+    - pull_request
+---
+kind: pipeline
+type: docker
+name: push-feature-build
+steps:
+- name: submodules
+  image: alpine/git
+  commands:
+  - git submodule update --init --recursive
+- name: push-feature-build
+  image: plugins/docker
+  settings:
+    repo: ${DRONE_REPO_NAMESPACE}/${DRONE_REPO_NAME}
+    tags: ${DRONE_BRANCH/\//-}
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    purge: true
+trigger:
+  branch:
+    - "*/*"
+  event:
+    exclude:
+      - pull_request
+---
+kind: pipeline
+type: docker
+name: push-release
+steps:
+- name: build-and-push-tag
+  image: plugins/docker
+  settings:
+    repo: ${DRONE_REPO}
+    tags: ${DRONE_TAG##v} # strips v from the tag
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+trigger:
+  event:
+  - tag
+---
+kind: pipeline
+type: docker
+name: dry-run
+steps:
+- name: dry-run
+  image: plugins/docker
+  settings:
+    repo: ${DRONE_REPO}
+    dry_run: true
+trigger:
+  event:
+  - pull_request

--- a/app.js
+++ b/app.js
@@ -68,22 +68,22 @@ async function getLocations(fuzzyRes){
   return results['LocationResult'];
 };
 
-// Note: BASISREGISTER_ADRESMATCH doesn't match if a param has special characters, such as accents.
-// To be able to process all the addresses, we need to make the values as simple as possible
+// Note: BASISREGISTER_ADRESMATCH doesn't match if a param has accents in it.
+// To be able to process all the addresses, we need to make the letters as simple as possible
 async function getBasisregisterAdresMatch(municipality, zipcode, thoroughfarename, housenumber){
   let queryParams = '';
 
   if(municipality)
-    queryParams += `GemeenteNaam=${replaceSpecialCharacters(municipality)}&`;
+    queryParams += `GemeenteNaam=${replaceAccents(municipality)}&`;
 
   if(zipcode)
-    queryParams += `Postcode=${replaceSpecialCharacters(zipcode)}&`;
+    queryParams += `Postcode=${replaceAccents(zipcode)}&`;
 
   if(thoroughfarename)
-    queryParams += `Straatnaam=${replaceSpecialCharacters(thoroughfarename)}&`;
+    queryParams += `Straatnaam=${replaceAccents(thoroughfarename)}&`;
 
   if(housenumber)
-    queryParams += `Huisnummer=${replaceSpecialCharacters(housenumber)}&`;
+    queryParams += `Huisnummer=${replaceAccents(housenumber)}&`;
 
   if(!queryParams) return [];
 
@@ -132,6 +132,6 @@ function tryJsonParse(str){
 }
 
 // From https://ricardometring.com/javascript-replace-special-characters
-function replaceSpecialCharacters(string) {
-  return string.normalize('NFD').replace(/([\u0300-\u036f]|[^0-9a-zA-Z\s])/g, '');
+function replaceAccents(string) {
+  return string.normalize('NFD').replace(/([\u0300-\u036f])/g, '');
 }

--- a/app.js
+++ b/app.js
@@ -68,20 +68,22 @@ async function getLocations(fuzzyRes){
   return results['LocationResult'];
 };
 
+// Note: BASISREGISTER_ADRESMATCH doesn't match if a param has special characters, such as accents.
+// To be able to process all the addresses, we need to make the values as simple as possible
 async function getBasisregisterAdresMatch(municipality, zipcode, thoroughfarename, housenumber){
   let queryParams = '';
 
   if(municipality)
-    queryParams += `GemeenteNaam=${municipality}&`;
+    queryParams += `GemeenteNaam=${replaceSpecialCharacters(municipality)}&`;
 
   if(zipcode)
-    queryParams += `Postcode=${zipcode}&`;
+    queryParams += `Postcode=${replaceSpecialCharacters(zipcode)}&`;
 
   if(thoroughfarename)
-    queryParams += `Straatnaam=${thoroughfarename}&`;
+    queryParams += `Straatnaam=${replaceSpecialCharacters(thoroughfarename)}&`;
 
   if(housenumber)
-    queryParams += `Huisnummer=${housenumber}&`;
+    queryParams += `Huisnummer=${replaceSpecialCharacters(housenumber)}&`;
 
   if(!queryParams) return [];
 
@@ -127,4 +129,9 @@ function tryJsonParse(str){
   catch (e) {
     return null;
   }
+}
+
+// From https://ricardometring.com/javascript-replace-special-characters
+function replaceSpecialCharacters(string) {
+  return string.normalize('NFD').replace(/([\u0300-\u036f]|[^0-9a-zA-Z\s])/g, '');
 }


### PR DESCRIPTION
See https://binnenland.atlassian.net/browse/OP-1063 for the bug case

When comparing the address given by `https://loc.geopunt.be/v4/Location` to addresses of `https://basisregisters.vlaanderen.be/api/v1/adressen`, we get a mismatch if we have a special characters in the `loc.geopunt` address. In the case of our bug, it's coming from an accent.

To fix this, we can filter out special characters from to compare both `loc.geopunt`'s result and have a match when we should.